### PR TITLE
Feature/pre commit2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        environment: [py310, py311, py312, py313]
+        environment: [py310]
     steps:
       - name: Fix .gitconfig if it is a directory
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
 
   # Formatter for python
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.2
+    rev: v0.12.7
     hooks:
 
       # Run the formatter.
@@ -50,7 +50,7 @@ repos:
         types_or: [ python, pyi ]
   # Checks for spelling mistakes
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0 
+    rev: v2.4.1 
     hooks:
       - id: codespell
         args: ["--write-changes","--ignore-words=./codespell-ignore.txt"]

--- a/pixi.lock
+++ b/pixi.lock
@@ -30,7 +30,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.1-h7b32b05_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.2-h26f9b46_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.8-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.2.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -66,7 +66,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/55/bf/9cb1ea5e3066779e42ade8d0cd3d3b0582a5720a814ae1586f85014656b6/ruff-0.12.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/75/8539d011f6be8e29f339c42e633aae3cb73bffa95dd0f9adec09b9c58e85/tomlkit-0.13.3-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
   py310:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -98,7 +98,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.1-h7b32b05_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.2-h26f9b46_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.8-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.2.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -137,7 +137,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/75/8539d011f6be8e29f339c42e633aae3cb73bffa95dd0f9adec09b9c58e85/tomlkit-0.13.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
   py311:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -169,7 +169,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.1-h7b32b05_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.2-h26f9b46_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.8-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.2.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -205,7 +205,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/55/bf/9cb1ea5e3066779e42ade8d0cd3d3b0582a5720a814ae1586f85014656b6/ruff-0.12.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/75/8539d011f6be8e29f339c42e633aae3cb73bffa95dd0f9adec09b9c58e85/tomlkit-0.13.3-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
   py312:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -237,7 +237,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.1-h7b32b05_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.2-h26f9b46_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.8-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.2.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -273,7 +273,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/55/bf/9cb1ea5e3066779e42ade8d0cd3d3b0582a5720a814ae1586f85014656b6/ruff-0.12.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/75/8539d011f6be8e29f339c42e633aae3cb73bffa95dd0f9adec09b9c58e85/tomlkit-0.13.3-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
   py313:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -304,7 +304,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.1-h7b32b05_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.2-h26f9b46_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.8-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.2.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -340,11 +340,13 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/55/bf/9cb1ea5e3066779e42ade8d0cd3d3b0582a5720a814ae1586f85014656b6/ruff-0.12.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/75/8539d011f6be8e29f339c42e633aae3cb73bffa95dd0f9adec09b9c58e85/tomlkit-0.13.3-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
   md5: d7c89558ba9fa0495403155b64376d81
+  arch: x86_64
+  platform: linux
   license: None
   purls: []
   size: 2562
@@ -358,6 +360,8 @@ packages:
   - libgomp >=7.5.0
   constrains:
   - openmp_impl 9999
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -494,6 +498,8 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: bzip2-1.0.6
   license_family: BSD
   purls: []
@@ -518,6 +524,8 @@ packages:
   - pycparser
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
   purls:
@@ -534,6 +542,8 @@ packages:
   - pycparser
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
   purls:
@@ -550,6 +560,8 @@ packages:
   - pycparser
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
   purls:
@@ -566,6 +578,8 @@ packages:
   - pycparser
   - python >=3.13.0rc1,<3.14.0a0
   - python_abi 3.13.* *_cp313
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
   purls:
@@ -736,6 +750,8 @@ packages:
   - __glibc >=2.17,<3.0.a0
   constrains:
   - binutils_impl_linux-64 2.44
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only
   license_family: GPL
   purls: []
@@ -749,6 +765,8 @@ packages:
   - libgcc >=14
   constrains:
   - expat 2.7.1.*
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -760,6 +778,8 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -774,6 +794,8 @@ packages:
   constrains:
   - libgcc-ng ==15.1.0=*_4
   - libgomp 15.1.0 h767d61c_4
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -784,6 +806,8 @@ packages:
   md5: 28771437ffcd9f3417c66012dc49a3be
   depends:
   - libgcc 15.1.0 h767d61c_4
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -794,6 +818,8 @@ packages:
   md5: 3baf8976c96134738bba224e9ef6b1e5
   depends:
   - __glibc >=2.17,<3.0.a0
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -807,6 +833,8 @@ packages:
   - libgcc >=13
   constrains:
   - xz 5.8.1.*
+  arch: x86_64
+  platform: linux
   license: 0BSD
   purls: []
   size: 112894
@@ -817,6 +845,8 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
+  arch: x86_64
+  platform: linux
   license: BSD-2-Clause
   license_family: BSD
   purls: []
@@ -828,6 +858,8 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
+  arch: x86_64
+  platform: linux
   license: LGPL-2.1-only
   license_family: GPL
   purls: []
@@ -840,6 +872,8 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libzlib >=1.3.1,<2.0a0
+  arch: x86_64
+  platform: linux
   license: blessing
   purls: []
   size: 932581
@@ -850,6 +884,8 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc 15.1.0 h767d61c_4
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -860,6 +896,8 @@ packages:
   md5: 40b61aab5c7ba9ff276c41cfffe6b80b
   depends:
   - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -870,6 +908,8 @@ packages:
   md5: 5aa797f8787fe7a17d1b0821485b5adc
   depends:
   - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: LGPL-2.1-or-later
   purls: []
   size: 100393
@@ -882,6 +922,8 @@ packages:
   - libgcc >=13
   constrains:
   - zlib 1.3.1 *_2
+  arch: x86_64
+  platform: linux
   license: Zlib
   license_family: Other
   purls: []
@@ -903,6 +945,8 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
+  arch: x86_64
+  platform: linux
   license: X11 AND BSD-3-Clause
   purls: []
   size: 891641
@@ -919,18 +963,20 @@ packages:
   - pkg:pypi/nodeenv?source=hash-mapping
   size: 34574
   timestamp: 1734112236147
-- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.1-h7b32b05_0.conda
-  sha256: 942347492164190559e995930adcdf84e2fea05307ec8012c02a505f5be87462
-  md5: c87df2ab1448ba69169652ab9547082d
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.2-h26f9b46_0.conda
+  sha256: c9f54d4e8212f313be7b02eb962d0cb13a8dae015683a403d3accd4add3e520e
+  md5: ffffb341206dd0dab0c36053c048d621
   depends:
   - __glibc >=2.17,<3.0.a0
   - ca-certificates
-  - libgcc >=13
+  - libgcc >=14
+  arch: x86_64
+  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 3131002
-  timestamp: 1751390382076
+  size: 3128847
+  timestamp: 1754465526100
 - pypi: https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl
   name: packaging
   version: '25.0'
@@ -1075,6 +1121,8 @@ packages:
   - tzdata
   constrains:
   - python_abi 3.10.* *_cp310
+  arch: x86_64
+  platform: linux
   license: Python-2.0
   purls: []
   size: 25042108
@@ -1102,6 +1150,8 @@ packages:
   - tzdata
   constrains:
   - python_abi 3.11.* *_cp311
+  arch: x86_64
+  platform: linux
   license: Python-2.0
   purls: []
   size: 30629559
@@ -1129,6 +1179,8 @@ packages:
   - tzdata
   constrains:
   - python_abi 3.12.* *_cp312
+  arch: x86_64
+  platform: linux
   license: Python-2.0
   purls: []
   size: 31445023
@@ -1155,6 +1207,8 @@ packages:
   - readline >=8.2,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
+  arch: x86_64
+  platform: linux
   license: Python-2.0
   purls: []
   size: 33273132
@@ -1213,6 +1267,8 @@ packages:
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
   - yaml >=0.2.5,<0.3.0a0
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
   purls:
@@ -1228,6 +1284,8 @@ packages:
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   - yaml >=0.2.5,<0.3.0a0
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
   purls:
@@ -1243,6 +1301,8 @@ packages:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - yaml >=0.2.5,<0.3.0a0
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
   purls:
@@ -1258,6 +1318,8 @@ packages:
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
   - yaml >=0.2.5,<0.3.0a0
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
   purls:
@@ -1270,6 +1332,8 @@ packages:
   depends:
   - libgcc >=13
   - ncurses >=6.5,<7.0a0
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only
   license_family: GPL
   purls: []
@@ -1302,6 +1366,8 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libzlib >=1.3.1,<2.0a0
+  arch: x86_64
+  platform: linux
   license: TCL
   license_family: BSD
   purls: []
@@ -1339,6 +1405,8 @@ packages:
   - libstdcxx >=13
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
   purls:
@@ -1355,6 +1423,8 @@ packages:
   - libstdcxx >=13
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
   purls:
@@ -1371,6 +1441,8 @@ packages:
   - libstdcxx >=13
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
   purls:
@@ -1387,6 +1459,8 @@ packages:
   - libstdcxx >=13
   - python >=3.13.0rc1,<3.14.0a0
   - python_abi 3.13.* *_cp313
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
   purls:
@@ -1406,7 +1480,7 @@ packages:
   - pkg:pypi/virtualenv?source=hash-mapping
   size: 4138678
   timestamp: 1754419391413
-- pypi: ./
+- pypi: .
   name: worktree-docker
   version: 0.0.1
   sha256: f7508d5c525aa43a0e1f63418379c57f38a1a97d9bee662974239cba72d36f41
@@ -1428,6 +1502,8 @@ packages:
   depends:
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
   purls: []

--- a/test/test_2_workflows.py
+++ b/test/test_2_workflows.py
@@ -29,25 +29,25 @@ def test_workflow_8_prune():
     output = run_workflow_script("test_workflow_8_prune.sh", allowed_returncodes=(0,))
     assert "=== TEST 1: SETUP TEST ENVIRONMENT ===" in output, "Test 1 setup not found"
     assert "=== TEST 2: SELECTIVE PRUNE TEST ===" in output, "Test 2 selective prune not found"
-    assert (
-        "=== TEST 3: SETUP MULTIPLE ENVIRONMENTS ===" in output
-    ), "Test 3 multiple setup not found"
+    assert "=== TEST 3: SETUP MULTIPLE ENVIRONMENTS ===" in output, (
+        "Test 3 multiple setup not found"
+    )
     assert "=== TEST 4: FULL PRUNE TEST ===" in output, "Test 4 full prune not found"
     assert "=== ALL PRUNE TESTS PASSED ===" in output, "Final success message not found"
     assert "✓ Selective prune completed" in output, "Selective prune did not complete"
     assert "✓ Full prune completed" in output, "Full prune did not complete"
-    assert (
-        "✓ Container correctly removed by selective prune" in output
-    ), "Selective prune did not remove container"
-    assert (
-        "✓ Worktree correctly removed by selective prune" in output
-    ), "Selective prune did not remove worktree"
-    assert (
-        "✓ All wtd containers correctly removed by full prune" in output
-    ), "Full prune did not remove all wtd containers"
-    assert (
-        "✓ .wtd directory correctly removed by full prune" in output
-    ), "Full prune did not remove .wtd directory"
+    assert "✓ Container correctly removed by selective prune" in output, (
+        "Selective prune did not remove container"
+    )
+    assert "✓ Worktree correctly removed by selective prune" in output, (
+        "Selective prune did not remove worktree"
+    )
+    assert "✓ All wtd containers correctly removed by full prune" in output, (
+        "Full prune did not remove all wtd containers"
+    )
+    assert "✓ .wtd directory correctly removed by full prune" in output, (
+        "Full prune did not remove .wtd directory"
+    )
 
 
 def test_workflow_5_force_rebuild_cache():
@@ -75,17 +75,17 @@ def test_workflow_5_force_rebuild_cache():
     force_time = int(force_match.group(1))
     reuse_time = int(reuse_match.group(1))
     nocache_time = int(nocache_match.group(1))
-    assert (
-        reuse_time <= force_time
-    ), f"Container reuse ({reuse_time}s) should be faster than force rebuild ({force_time}s)"
+    assert reuse_time <= force_time, (
+        f"Container reuse ({reuse_time}s) should be faster than force rebuild ({force_time}s)"
+    )
     if nocache_time > 5:
-        assert (
-            force_time <= nocache_time + 2
-        ), f"Force rebuild with cache ({force_time}s) should be close to or faster than no-cache ({nocache_time}s)"
+        assert force_time <= nocache_time + 2, (
+            f"Force rebuild with cache ({force_time}s) should be close to or faster than no-cache ({nocache_time}s)"
+        )
     if "Force rebuild: removing existing container" in output:
-        assert (
-            "Creating new persistent container" in output
-        ), "Should create new container after force removal"
+        assert "Creating new persistent container" in output, (
+            "Should create new container after force removal"
+        )
     print(
         f"Cache test performance: initial={initial_time}s, force={force_time}s, nocache={nocache_time}s, reuse={reuse_time}s"
     )
@@ -96,12 +96,12 @@ def test_workflow_12_nocache():
     assert "=== TEST: NOCACHE FEATURE ===" in output, "Test start not found"
     assert "=== NOCACHE FEATURE TEST PASSED ===" in output, "Test completion not found"
     assert "✓ --nocache option appears in help" in output, "Nocache option in help not confirmed"
-    assert (
-        "✓ --no-cache flag passed to buildx bake command" in output
-    ), "Nocache flag usage not confirmed"
-    assert (
-        "✓ Environment works correctly with --nocache" in output
-    ), "Environment functionality not confirmed"
+    assert "✓ --no-cache flag passed to buildx bake command" in output, (
+        "Nocache flag usage not confirmed"
+    )
+    assert "✓ Environment works correctly with --nocache" in output, (
+        "Environment functionality not confirmed"
+    )
     assert "✓ Git status shows clean workspace" in output, "Clean workspace not confirmed"
     assert "✓ Global --nocache flag works" in output, "Global nocache flag not confirmed"
 
@@ -109,16 +109,16 @@ def test_workflow_12_nocache():
 def test_workflow_3_cmd():
     output = run_workflow_script("test_workflow_3_cmd.sh")
     assert "On branch" in output, "Expected git status 'On branch' not found in workflow 3 output"
-    assert (
-        "/tmp/test_wtd" in output or "test_wtd" in output
-    ), "Expected working directory 'test_wtd' not found in workflow 3 output"
+    assert "/tmp/test_wtd" in output or "test_wtd" in output, (
+        "Expected working directory 'test_wtd' not found in workflow 3 output"
+    )
 
 
 def test_workflow_4_persistent():
     output = run_workflow_script("test_workflow_4_persistent.sh")
-    assert (
-        "persistent.txt" in output
-    ), "Expected persistent file 'persistent.txt' not found in workflow 4 persistent output"
+    assert "persistent.txt" in output, (
+        "Expected persistent file 'persistent.txt' not found in workflow 4 persistent output"
+    )
 
 
 def test_workflow_6_clean_git():
@@ -127,26 +127,26 @@ def test_workflow_6_clean_git():
 
 def test_workflow_9_container_reuse():
     output = run_workflow_script("test_workflow_9_container_reuse.sh", allowed_returncodes=(0,))
-    assert (
-        "=== TEST 1: CREATE INITIAL ENVIRONMENT ===" in output
-    ), "Test 1 create environment not found"
+    assert "=== TEST 1: CREATE INITIAL ENVIRONMENT ===" in output, (
+        "Test 1 create environment not found"
+    )
     assert "=== TEST 2: TEST CONTAINER REUSE ===" in output, "Test 2 container reuse not found"
-    assert (
-        "=== TEST 3: TEST CONTAINER RECREATION AFTER STOP ===" in output
-    ), "Test 3 recreation after stop not found"
-    assert (
-        "=== TEST 4: TEST REUSE OF RECREATED CONTAINER ===" in output
-    ), "Test 4 reuse of recreated not found"
+    assert "=== TEST 3: TEST CONTAINER RECREATION AFTER STOP ===" in output, (
+        "Test 3 recreation after stop not found"
+    )
+    assert "=== TEST 4: TEST REUSE OF RECREATED CONTAINER ===" in output, (
+        "Test 4 reuse of recreated not found"
+    )
     assert "=== ALL CONTAINER REUSE TESTS PASSED ===" in output, "Final success message not found"
-    assert (
-        "✓ Container was reused (same ID:" in output
-    ), "Container was not reused when it should have been"
-    assert (
-        "✓ Container was correctly recreated after being stopped" in output
-    ), "Container was not recreated when stopped"
-    assert (
-        "✓ Recreated container was reused (same ID:" in output
-    ), "Recreated container was not reused"
+    assert "✓ Container was reused (same ID:" in output, (
+        "Container was not reused when it should have been"
+    )
+    assert "✓ Container was correctly recreated after being stopped" in output, (
+        "Container was not recreated when stopped"
+    )
+    assert "✓ Recreated container was reused (same ID:" in output, (
+        "Recreated container was not reused"
+    )
     lines = output.split("\n")
     container_reuse_found = False
     stale_removal_after_reuse = False
@@ -158,17 +158,17 @@ def test_workflow_9_container_reuse():
                     stale_removal_after_reuse = True
                     break
     assert container_reuse_found, "Container reuse confirmation not found"
-    assert (
-        not stale_removal_after_reuse
-    ), "Stale container removal should not happen when reusing existing container"
+    assert not stale_removal_after_reuse, (
+        "Stale container removal should not happen when reusing existing container"
+    )
 
 
 def test_workflow_10_new_branch():
     output = run_workflow_script("test_workflow_10_new_branch.sh", allowed_returncodes=(0,))
     assert "=== TEST: NEW BRANCH WORKFLOW WITH PRUNE ===" in output, "Test start not found"
-    assert (
-        "=== NEW BRANCH WORKFLOW WITH PRUNE TEST PASSED ===" in output
-    ), "Test completion not found"
+    assert "=== NEW BRANCH WORKFLOW WITH PRUNE TEST PASSED ===" in output, (
+        "Test completion not found"
+    )
     assert "=== STEP 1: INITIAL CLEANUP ===" in output, "Step 1 not found"
     assert "=== STEP 2: CREATE NEW BRANCH ENVIRONMENT ===" in output, "Step 2 not found"
     assert "=== STEP 3: VERIFY NEW BRANCH ENVIRONMENT ===" in output, "Step 3 not found"
@@ -177,56 +177,56 @@ def test_workflow_10_new_branch():
     assert "=== STEP 6: RECREATE ENVIRONMENT FOR FULL PRUNE TEST ===" in output, "Step 6 not found"
     assert "=== STEP 7: TEST FULL PRUNE ===" in output, "Step 7 not found"
     assert "=== STEP 8: VERIFY WORKFLOW WORKS AFTER FULL PRUNE ===" in output, "Step 8 not found"
-    assert (
-        "✓ Successfully created worktree for new branch and ran git status" in output
-    ), "Worktree creation not confirmed"
+    assert "✓ Successfully created worktree for new branch and ran git status" in output, (
+        "Worktree creation not confirmed"
+    )
     assert "✓ Confirmed on new branch 'new_branch'" in output, "Branch creation not confirmed"
     assert "✓ Workspace is clean as expected" in output, "Clean workspace not confirmed"
-    assert (
-        "✓ Container for new branch environment is running" in output
-    ), "Container existence not confirmed"
-    assert (
-        "✓ Container correctly removed by selective prune" in output
-    ), "Selective prune container removal not confirmed"
-    assert (
-        "✓ Worktree correctly removed by selective prune" in output
-    ), "Selective prune worktree removal not confirmed"
+    assert "✓ Container for new branch environment is running" in output, (
+        "Container existence not confirmed"
+    )
+    assert "✓ Container correctly removed by selective prune" in output, (
+        "Selective prune container removal not confirmed"
+    )
+    assert "✓ Worktree correctly removed by selective prune" in output, (
+        "Selective prune worktree removal not confirmed"
+    )
     assert "✓ Selective prune completed" in output, "Selective prune not completed"
     assert "✓ Full prune completed" in output, "Full prune not completed"
-    assert (
-        "✓ All wtd containers correctly removed by full prune" in output
-    ), "Full prune container removal not confirmed"
-    assert (
-        "✓ .wtd directory correctly removed by full prune" in output
-    ), "Full prune directory removal not confirmed"
-    assert (
-        "✓ New branch workflow still works after full prune" in output
-    ), "Workflow recovery not confirmed"
+    assert "✓ All wtd containers correctly removed by full prune" in output, (
+        "Full prune container removal not confirmed"
+    )
+    assert "✓ .wtd directory correctly removed by full prune" in output, (
+        "Full prune directory removal not confirmed"
+    )
+    assert "✓ New branch workflow still works after full prune" in output, (
+        "Workflow recovery not confirmed"
+    )
     assert "On branch new_branch" in output, "Git status doesn't show correct branch"
-    assert (
-        "nothing to commit, working tree clean" in output
-    ), "Git status doesn't show clean workspace"
+    assert "nothing to commit, working tree clean" in output, (
+        "Git status doesn't show clean workspace"
+    )
 
 
 def test_workflow_11_install_completion():
     output = run_workflow_script("test_workflow_11_install_completion.sh", allowed_returncodes=(0,))
     assert "=== TEST: SHELL COMPLETION INSTALLATION ===" in output, "Test start not found"
-    assert (
-        "=== SHELL COMPLETION INSTALLATION TEST PASSED ===" in output
-    ), "Test completion not found"
-    assert (
-        "✓ Bash completion file created successfully" in output
-    ), "Bash completion creation not confirmed"
-    assert (
-        "✓ Bash completion contains expected function" in output
-    ), "Bash completion function not confirmed"
-    assert (
-        "✓ Bash completion contains correct commands (no destroy)" in output
-    ), "Bash completion commands not confirmed"
-    assert (
-        "✓ Bash completion script syntax is valid" in output
-    ), "Bash completion syntax not confirmed"
+    assert "=== SHELL COMPLETION INSTALLATION TEST PASSED ===" in output, (
+        "Test completion not found"
+    )
+    assert "✓ Bash completion file created successfully" in output, (
+        "Bash completion creation not confirmed"
+    )
+    assert "✓ Bash completion contains expected function" in output, (
+        "Bash completion function not confirmed"
+    )
+    assert "✓ Bash completion contains correct commands (no destroy)" in output, (
+        "Bash completion commands not confirmed"
+    )
+    assert "✓ Bash completion script syntax is valid" in output, (
+        "Bash completion syntax not confirmed"
+    )
     assert "✓ Help shows --install option" in output, "Help install option not confirmed"
-    assert (
-        "✓ Handles unsupported shell gracefully" in output
-    ), "Unsupported shell handling not confirmed"
+    assert "✓ Handles unsupported shell gracefully" in output, (
+        "Unsupported shell handling not confirmed"
+    )


### PR DESCRIPTION
## Summary by Sourcery

Standardize test assertion formatting, upgrade pre-commit hook versions, and simplify CI matrix to Python 3.10

Enhancements:
- Refactor test suite to use inline assertion parentheses for improved readability

Build:
- Bump ruff-pre-commit to v0.12.7 and codespell to v2.4.1 in .pre-commit-config.yaml

CI:
- Restrict GitHub Actions CI matrix to run only on Python 3.10